### PR TITLE
Cherry-pick upstream 43a3ca422337551ef4d2fb1331e8b765e0e13d0a

### DIFF
--- a/telepathy-qt/TelepathyQt/contact-manager.cpp
+++ b/telepathy-qt/TelepathyQt/contact-manager.cpp
@@ -1341,17 +1341,27 @@ void ContactManager::onAvatarRetrieved(uint handle, const QString &token,
         debug() << "Filename:" << avatarFileName;
         debug() << "MimeType:" << mimeType;
 
-        QTemporaryFile mimeTypeFile(mimeTypeFileName);
-        mimeTypeFile.open();
-        mimeTypeFile.write(mimeType.toLatin1());
-        mimeTypeFile.setAutoRemove(false);
-        mimeTypeFile.rename(mimeTypeFileName);
+        if (!QFile::exists(mimeTypeFileName)) {
+            QTemporaryFile mimeTypeFile(mimeTypeFileName);
+            if (mimeTypeFile.open()) {
+                mimeTypeFile.write(mimeType.toLatin1());
+                mimeTypeFile.setAutoRemove(false);
+                if (!mimeTypeFile.rename(mimeTypeFileName)) {
+                    mimeTypeFile.remove();
+                }
+            }
+        }
 
-        QTemporaryFile avatarFile(avatarFileName);
-        avatarFile.open();
-        avatarFile.write(data);
-        avatarFile.setAutoRemove(false);
-        avatarFile.rename(avatarFileName);
+        if (!QFile::exists(avatarFileName)) {
+            QTemporaryFile avatarFile(avatarFileName);
+            if (avatarFile.open()) {
+                avatarFile.write(data);
+                avatarFile.setAutoRemove(false);
+                if (!avatarFile.rename(avatarFileName)) {
+                    avatarFile.remove();
+                }
+            }
+        }
     }
 
     ContactPtr contact = lookupContactByHandle(handle);


### PR DESCRIPTION
Fix storing avatars, so that they are not stored millions of times each
## 

None of the few other patches in telepathy-qt upstream are immediately relevant to us, and I don't want to deal with the build failures and conflicts with the Qt5 patch right now. This one is useful.
