### PR TITLE
[telepathy-qt] Fix Qt5 pkgconfig dependencies for Farstream

### DIFF
--- a/telepathy-qt/TelepathyQt/Farstream/TelepathyQtFarstream-uninstalled.pc.in
+++ b/telepathy-qt/TelepathyQt/Farstream/TelepathyQtFarstream-uninstalled.pc.in
@@ -6,6 +6,6 @@ abs_top_srcdir=${CMAKE_SOURCE_DIR}
 Name: TelepathyQt${QT_VERSION_MAJOR}Farstream (uninstalled copy)
 Description: Qt Telepathy Farstream utility library for the Telepathy framework
 Version: ${PACKAGE_VERSION}
-Requires.private: QtCore >= ${QT_MIN_VERSION}, QtCore < ${QT_MAX_VERSION}, QtDBus >= ${QT_MIN_VERSION}, QtDBus < ${QT_MAX_VERSION}, telepathy-glib >= ${TELEPATHY_GLIB_MIN_VERSION}, telepathy-farstream >= ${TELEPATHY_FARSTREAM_MIN_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
+Requires.private: Qt${QT_VERSION_PC}Core >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}Core < ${QT_MAX_VERSION}, Qt${QT_VERSION_PC}DBus >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}DBus < ${QT_MAX_VERSION}, telepathy-glib >= ${TELEPATHY_GLIB_MIN_VERSION}, telepathy-farstream >= ${TELEPATHY_FARSTREAM_MIN_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
 Libs: ${CMAKE_BINARY_DIR}/TelepathyQt${QT_VERSION_MAJOR}/Farstream/libtelepathy-qt${QT_VERSION_MAJOR}-farstream.so
 Cflags: -I${CMAKE_SOURCE_DIR} -I${CMAKE_BINARY_DIR}

--- a/telepathy-qt/TelepathyQt/Farstream/TelepathyQtFarstream.pc.in
+++ b/telepathy-qt/TelepathyQt/Farstream/TelepathyQtFarstream.pc.in
@@ -6,6 +6,6 @@ includedir=${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}
 Name: TelepathyQt${QT_VERSION_MAJOR}Farstream
 Description: Qt Telepathy Farstream utility library for the Telepathy framework
 Version: ${PACKAGE_VERSION}
-Requires.private: QtCore >= ${QT_MIN_VERSION}, QtCore < ${QT_MAX_VERSION}, QtDBus >= ${QT_MIN_VERSION}, QtDBus < ${QT_MAX_VERSION}, telepathy-glib >= ${TELEPATHY_GLIB_MIN_VERSION}, telepathy-farstream >= ${TELEPATHY_FARSTREAM_MIN_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
+Requires.private: Qt${QT_VERSION_PC}Core >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}Core < ${QT_MAX_VERSION}, Qt${QT_VERSION_PC}DBus >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}DBus < ${QT_MAX_VERSION}, telepathy-glib >= ${TELEPATHY_GLIB_MIN_VERSION}, telepathy-farstream >= ${TELEPATHY_FARSTREAM_MIN_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
 Libs: -L${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR} -ltelepathy-qt${QT_VERSION_MAJOR}-farstream
 Cflags: -I${CMAKE_INSTALL_PREFIX}/${INCLUDE_INSTALL_DIR}/telepathy-qt${QT_VERSION_MAJOR}

--- a/telepathy-qt/TelepathyQt/TelepathyQtService-uninstalled.pc.in
+++ b/telepathy-qt/TelepathyQt/TelepathyQtService-uninstalled.pc.in
@@ -6,6 +6,6 @@ abs_top_srcdir=${CMAKE_SOURCE_DIR}
 Name: TelepathyQt${QT_VERSION_MAJOR}Service (uninstalled copy)
 Description: Qt Telepathy Service side bindings
 Version: ${PACKAGE_VERSION}
-Requires.private: QtCore >= ${QT_MIN_VERSION}, QtCore < ${QT_MAX_VERSION}, QtDBus >= ${QT_MIN_VERSION}, QtDBus < ${QT_MAX_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
+Requires.private: Qt${QT_VERSION_PC}Core >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}Core < ${QT_MAX_VERSION}, Qt${QT_VERSION_PC}DBus >= ${QT_MIN_VERSION}, Qt${QT_VERSION_PC}DBus < ${QT_MAX_VERSION}, TelepathyQt${QT_VERSION_MAJOR} = ${PACKAGE_VERSION}
 Libs: ${CMAKE_BINARY_DIR}/TelepathyQt/Farsight/libtelepathy-qt${QT_VERSION_MAJOR}-service.so
 Cflags: -I${CMAKE_SOURCE_DIR} -I${CMAKE_BINARY_DIR}


### PR DESCRIPTION
0191a6dd fixed the pkgconfig dependencies for Qt5, but missed updating
TelepathyQtFarstream and two other files.
